### PR TITLE
fix(ci): run release-please on main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore: release') || startsWith(github.event.head_commit.message, 'chore(master): release')"
+    if: "startsWith(github.event.head_commit.message, 'chore: release') || startsWith(github.event.head_commit.message, 'chore(main): release')"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -38,7 +38,7 @@ jobs:
 
   update-pr:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(master): release')"
+    if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     steps:
       - uses: googleapis/release-please-action@v5
         id: release


### PR DESCRIPTION
## Summary
- Fix release-please workflow trigger after renaming the default branch to main
- Update release commit guards from chore(master): release to chore(main): release

## Root cause
PR #2 merged successfully, but no release PR appeared because `.github/workflows/release-please.yml` still listened to pushes on `master`. The repository default branch is now `main`, so the workflow never ran.

## Verification
- ruby YAML parse for `.github/workflows/release-please.yml`
- actionlint for `.github/workflows/release-please.yml`