### PR TITLE
fix(ci): build draft releases from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,12 +8,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 jobs:
-  release:
+  release-please:
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore: release') || startsWith(github.event.head_commit.message, 'chore(main): release')"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -24,25 +22,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          skip-github-pull-request: true
 
-      - name: Trigger release build workflow
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Release created: ${{ steps.release.outputs.tag_name }}"
-          gh workflow run release.yml \
-            --repo "${{ github.repository }}" \
-            --field "tag_name=${{ steps.release.outputs.tag_name }}"
-
-  update-pr:
-    runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(main): release')"
-    steps:
-      - uses: googleapis/release-please-action@v5
-        id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+  build-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
           else
             gh release create "${RELEASE_TAG}" artifacts/* \
               --repo "${REPOSITORY}" \
+              --draft \
               --title "${RELEASE_TAG}" \
               --generate-notes
           fi

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-v-in-tag": true,
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "package-name": "OneTiny",


### PR DESCRIPTION
## Summary
- run release-please in a single job and use its release_created/tag_name outputs to call the reusable release build workflow
- create release-please releases as drafts and force tag creation so release.yml can checkout the tag before publish
- make manual release.yml fallback create draft releases too

## Root cause
The release PR was merged with a merge commit whose message starts with "Merge pull request ...". The old workflow split release/update-pr jobs by checking head_commit.message for chore(main): release, so the release job was skipped. The update-pr job still created the GitHub release/tag, but nothing triggered packaging.

## Verification
- ruby YAML parse for .github/workflows/release-please.yml
- ruby JSON parse for release-please-config.json
- go run github.com/rhysd/actionlint/cmd/actionlint@latest