### PR TITLE
fix(deps): update eutil to v0.0.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md instructions
+
+- 始终使用简体中文回复。
+- 运行 shell 命令时默认加 `rtk` 前缀。
+
+## 发版
+
+OneTiny 走 `release-please`。正常发版不要手动建 tag 或 `gh release create`，把 release-please 创建的 release PR 合并即可触发发版和构建。
+
+示例：
+
+```bash
+rtk gh pr list --state open --search "release-please in:title"
+rtk gh pr merge <PR_NUMBER> --merge --delete-branch
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/TCP404/OneTiny-cli
 go 1.26
 
 require (
-	github.com/TCP404/eutil v0.0.5
+	github.com/TCP404/eutil v0.0.11
 	github.com/fatih/color v1.18.0
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
-github.com/TCP404/eutil v0.0.5 h1:/5pOs1NfaFQP3QtOL4Hp+CnDZuB4tjZPz6jPt2xZ41I=
-github.com/TCP404/eutil v0.0.5/go.mod h1:SXMR1WFmqPr7mERx5AjqUXCVwiOn+g+gPEzU5b+geLc=
+github.com/TCP404/eutil v0.0.11 h1:3vY0QbJbejvUfwWtlbQHcmX8hOmxSssnTKeXaeVCHBg=
+github.com/TCP404/eutil v0.0.11/go.mod h1:K+yaXPtPpUxa5n3/EyaEJ2cRKlswaDVt/e0b3BKw8vs=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=


### PR DESCRIPTION
## Summary

- Update `github.com/TCP404/eutil` to `v0.0.11`
- Pull in the local IP selection fix for LAN addresses
- Document the release-please PR merge flow in `AGENTS.md`

## Tests

- `go test ./...`