### PR TITLE
chore(release): keep pre-1.0 breaking changes minor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
   "draft": true,
   "force-tag-creation": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Configure release-please to bump minor, not major, for breaking changes while the project is below 1.0.0.
- This should update the current release PR from 1.0.0 to 0.9.0 after merging.

## Test Plan
- jq . release-please-config.json