### PR TITLE
docs(build): fix stale just recipe names

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -51,14 +51,14 @@ dist/onetiny-checksums.txt
 本地优先使用 `just`：
 
 ```bash
-rtk just info
+rtk just dev-info
 rtk just check
 rtk just cli
 rtk just gui
 rtk just dev
 rtk just hooks-install
-rtk just precommit
-rtk just prepush
+rtk just check-precommit
+rtk just check-prepush
 ```
 
 需要复现 CI 时使用 `task`：


### PR DESCRIPTION
## What

Update `docs/build.md` 的「常用命令」示例，对齐 justfile 里已 namespace 化的 recipe 名。

## Why

main 的 justfile recipe 已改名（`info` → `dev-info`，`precommit` → `check-precommit`，`prepush` → `check-prepush`），但 `docs/build.md` 仍写旧名，doc 与代码不一致。

## Changes

- `just info` → `just dev-info`
- `just precommit` → `just check-precommit`
- `just prepush` → `just check-prepush`

其余 recipe（`check`/`dev`/`cli`/`gui`/`hooks-install`）未变，文档保持不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)